### PR TITLE
Fix opt parsing with more than 5 options

### DIFF
--- a/modules/opt.sh
+++ b/modules/opt.sh
@@ -134,7 +134,7 @@ function b.opt.init () {
     arg=$(b.opt.alias2opt $arg)
     if b.opt.is_opt? "$arg"; then
       local ii=$(($i + 1))
-      local nextArg=$(eval "echo \$$ii")
+      local nextArg=$(eval "echo \${$ii}")
       if [ -z "$nextArg" ] || b.opt.is_opt? "$nextArg" || b.opt.is_flag? "$nextArg"; then
         b.raise ArgumentError "Option '$arg' requires an argument."
       else

--- a/tests/modules/opt_test.sh
+++ b/tests/modules/opt_test.sh
@@ -122,14 +122,3 @@ function b.test.test_usage_output () {
   b.opt.show_usage | grep -q -e '--email|-e'
   b.unittest.assert_success $?
 }
-
-b.unittest.add_test_case b.test.if_options_exists "Test b.opt options"
-b.unittest.add_test_case b.test.if_flag_exists "Test b.opt flags"
-b.unittest.add_test_case b.test.option_and_flag_aliasing "Test both, option and flag aliasing"
-b.unittest.add_test_case b.test.multiple_alias_for_single_option "Test multiple aliases for the same optino"
-b.unittest.add_test_case b.test.required_arg_not_present "Test behavior for required args"
-b.unittest.add_test_case b.test.required_arg_called_with_long_args "Test behavior for required args"
-b.unittest.add_test_case b.test.required_arg_called_with_short_args "Test behavior for required args"
-b.unittest.add_test_case b.test.has_flag_set "Test whether has_flag? returns the right exit code"
-b.unittest.add_test_case b.test.has_not_flag_set "Test whether has_flag? returns the right exit code"
-b.unittest.add_test_case b.test.get_opt "Test whether get_opt works"

--- a/tests/modules/opt_test.sh
+++ b/tests/modules/opt_test.sh
@@ -1,7 +1,3 @@
-#!/bin/bash
-
-b.module.require opt
-
 function b.unittest.teardown {
   b.opt.reset
 }
@@ -121,4 +117,20 @@ function b.test.test_usage_output () {
 
   b.opt.show_usage | grep -q -e '--email|-e'
   b.unittest.assert_success $?
+}
+
+function b.test.test_more_than_five_options () {
+  b.opt.add_opt --opt1
+  b.opt.add_opt --opt2
+  b.opt.add_opt --opt3
+  b.opt.add_opt --opt4
+  b.opt.add_opt --opt5
+
+  b.init --opt1 one --company two --grove three --index four --password five
+
+  b.opt.assert_equal "$(b.opt.get_opt --opt1)" "one"
+  b.opt.assert_equal "$(b.opt.get_opt --opt2)" "two"
+  b.opt.assert_equal "$(b.opt.get_opt --opt3)" "three"
+  b.opt.assert_equal "$(b.opt.get_opt --opt4)" "four"
+  b.opt.assert_equal "$(b.opt.get_opt --opt5)" "five"
 }


### PR DESCRIPTION
Because of `eval "echo \$$ii"`, when `$ii > 9`, only the first digit was being interpreted. This PR fixes it and closes #18 
